### PR TITLE
PR for #33: Switch default precision for parenthetical reference value

### DIFF
--- a/xtevent/xteventplot.ado
+++ b/xtevent/xteventplot.ado
@@ -478,13 +478,15 @@ program define xteventplot
 	}
 	else loc note ""
 	
+	* Set parenthetical reference value
+	
 	if "`proxy'"!="" {
-		loc y1plot : di %-9.2f `=e(x1)'
+		loc y1plot : di %9.4g `=e(x1)'
 		loc y1plot=strtrim("`y1plot'")
 		loc y1plot `""0 (`y1plot')" "'
 	}
 	else {
-		loc y1plot : di %-9.2f `=e(y1)'
+		loc y1plot : di %9.4g `=e(y1)'
 		loc y1plot=strtrim("`y1plot'")
 		loc y1plot `""0 (`y1plot')" "'
 	}
@@ -498,7 +500,6 @@ program define xteventplot
 		svmat mattrendy, names(`trendy')
 		svmat mattrendx, names(`trendx')
 		loc trendplot "lfit `trendy'1 `trendx'1, range(`=`kmin'+1' `=`kmax'-1')"
-		
 	}
 		
 	* Plot
@@ -770,7 +771,6 @@ mata
 		a1 = -pinv(i.A1)*(i.Ab*b+i.A2*a2)
 		
 		aresult = (b\a1\a2)
-		
 	}
 
 	/* Solution if number of normalized coefficients = polynomial order */


### PR DESCRIPTION
Switched to "%9.4g", which allows 4 significant figures that Stata chooses based on the number displayed. For instance, the number 3.14159265 in %9.4g format is displayed as 3.142, 31.4159265 as 31.42, etc... If we switched to "di %9.4f", we would allow for 4 decimal places in a fixed format.