### PR TITLE
PR for #16: obtaining the regular DiD estimates

### DIFF
--- a/test/test.do
+++ b/test/test.do
@@ -4,10 +4,6 @@ cap log using test.log, replace text
 
 clear all
 
-if "`c(username)'" == "rayhuang" {
-	cd "/Users/rayhuang/Documents/JMSLab/xtevent-git/test"
-	}
-set scheme sj
 /*=========================================================================
                         1: Load data 
 ===========================================================================*/	
@@ -22,7 +18,7 @@ graph drop _all
 
 *------------------------ 2.1: Replicate 2a and test basic funcionality ----------------------------------
 
-xtevent y eta , panelvar(i) timevar(t) policyvar(z) window(5) trend plot
+xtevent y eta , panelvar(i) timevar(t) policyvar(z) window(5)
 
 * Testing xtset options
 

--- a/test/test.do
+++ b/test/test.do
@@ -111,7 +111,7 @@ xtevent y eta, panelvar(i) timevar(t) policyvar(z) window(5) norm(-2) plot
 xtevent y eta, panelvar(i) timevar(t) policyvar(z) window(5) norm(-6) plot
 * xtevent y eta, panelvar(i) timevar(t) policyvar(z) window(5) norm(-7) plot
 xtevent y eta, panelvar(i) timevar(t) policyvar(z) window(5) norm(1) plot 
-xtevent y eta, panelvar(i) timevar(t) policyvar(z) window(5) norm(5)plot 
+xtevent y eta, panelvar(i) timevar(t) policyvar(z) window(5) norm(5) plot 
 
 graph drop _all
 
@@ -155,6 +155,13 @@ drop z_imputed
 replace z=0.5 in 7
 xtevent y eta, policyvar(z) timevar(t) window(5) impute(instag)
 replace z=1 in 7
+
+*Difference in averages between the post and pre-period
+xtevent y eta , panelvar(i) timevar(t) policyvar(z) window(5) diffavg
+xtevent y eta , panelvar(i) timevar(t) policyvar(z) window(4) diff
+xtevent y eta , panelvar(i) timevar(t) policyvar(z) window(5) norm(1) diff
+xtevent y eta , panelvar(i) timevar(t) policyvar(z) window(5) norm(2) diff
+xtevent y eta , panelvar(i) timevar(t) policyvar(z) window(5) norm(-2) diff
 
 *Trend adjustment. Default method is GMM
 xtevent y eta, policyvar(z) timevar(t) window(5) trend(-3)

--- a/test/test.do
+++ b/test/test.do
@@ -4,6 +4,10 @@ cap log using test.log, replace text
 
 clear all
 
+if "`c(username)'" == "rayhuang" {
+	cd "/Users/rayhuang/Documents/JMSLab/xtevent-git/test"
+	}
+set scheme sj
 /*=========================================================================
                         1: Load data 
 ===========================================================================*/	
@@ -18,7 +22,7 @@ graph drop _all
 
 *------------------------ 2.1: Replicate 2a and test basic funcionality ----------------------------------
 
-xtevent y eta , panelvar(i) timevar(t) policyvar(z) window(5)
+xtevent y eta , panelvar(i) timevar(t) policyvar(z) window(5) trend plot
 
 * Testing xtset options
 

--- a/xtevent/_eventols.ado
+++ b/xtevent/_eventols.ado
@@ -200,15 +200,20 @@ program define _eventols, rclass
 		unab pre : _k_eq_m*
 		unab post_p : _k_eq_p*
 		loc norma = abs(`norm')
-		loc pre : subinstr local pre "_k_eq_m`norma'" "", all
-		loc pre_plus : subinstr local pre " " " + ", all
-		loc reverse = ustrreverse("`pre_plus'")
-		loc reverse = subinstr("`reverse'", " + ", "", 1)
-		loc pre_plus = ustrreverse("`reverse'")
+		if `norm' < 0{
+			loc pre : subinstr local pre "_k_eq_m`norma'" "", all
+			loc pre_plus : subinstr local pre " " " + ", all
+			loc reverse = ustrreverse("`pre_plus'")
+			loc reverse = subinstr("`reverse'", " + ", "", 1)
+			loc pre_plus = ustrreverse("`reverse'")
+		}
+		if `norm' >= 0{
+			loc post_p : subinstr local post_p "_k_eq_p`norma' " "", all
+			loc pre_plus : subinstr local pre " " " + ", all
+		}
 		loc post_plus : subinstr local post_p " " " + ", all
 		loc lwindow = abs(`lwindow')
 		loc rwindow = `rwindow'
-		
 		di as text _n "Difference in pre and post-period averages from lincom:"
 		lincom ((`post_plus') / (`rwindow' + 2)) - ((`pre_plus') / (`lwindow' + 1)), cformat(%9.4g)
 	}

--- a/xtevent/_eventols.ado
+++ b/xtevent/_eventols.ado
@@ -21,6 +21,7 @@ program define _eventols, rclass
 	reghdfe /* Use reghdfe for estimation */	
 	impute(string) /*imputation on policyvar*/
 	absorb(string) /* Absorb additional variables in reghdfe */ 
+	staticDD /* Obtain regular DiD estimate implied by the model */
 	*
 	]
 	;
@@ -192,6 +193,21 @@ program define _eventols, rclass
 	loc df = e(df_r)
 	
 	gen byte `esample' = e(sample)
+	
+	* DiD estimate 
+	
+	loc lwindow abs(`lwindow')
+	loc rwindow `rwindow'
+	if "`staticDD'"!=""{
+		mat pre_mat = `delta'[1...,1..`lwindow'] 
+		mat post_mat = `delta'[1...,(1+`lwindow')...]
+		mat pre_total = (pre_mat * J(colsof(pre_mat), 1, 1)) / (`lwindow' + 1)
+		mat post_total = (post_mat * J(colsof(post_mat), 1, 1)) / (`rwindow' + 2)
+		mat diff = post_total - pre_total
+		scalar diff_scalar = diff[1,1] 
+		di as text _n "DiD estimate:"
+		di diff_scalar
+	}
 	
 	* Trend adjustment by GMM
 	

--- a/xtevent/_eventols.ado
+++ b/xtevent/_eventols.ado
@@ -195,20 +195,27 @@ program define _eventols, rclass
 	gen byte `esample' = e(sample)
 	
 	* DiD estimate 
-	
+	tempname pre_mat post_mat pre_total post_total diff diff_scalar
 	loc lwindow abs(`lwindow')
 	loc rwindow `rwindow'
 	if "`staticDD'"!=""{
-		mat pre_mat = `delta'[1...,1..`lwindow'] 
-		mat post_mat = `delta'[1...,(1+`lwindow')...]
-		mat pre_total = (pre_mat * J(colsof(pre_mat), 1, 1)) / (`lwindow' + 1)
-		mat post_total = (post_mat * J(colsof(post_mat), 1, 1)) / (`rwindow' + 2)
-		mat diff = post_total - pre_total
-		scalar diff_scalar = diff[1,1] 
+		mat `pre_mat' = `delta'[1...,1..`lwindow'] 
+		mat `post_mat' = `delta'[1...,(1+`lwindow')...]
+		mat `pre_total' = (`pre_mat' * J(colsof(`pre_mat'), 1, 1)) / (`lwindow' + 1)
+		mat `post_total' = (`post_mat' * J(colsof(`post_mat'), 1, 1)) / (`rwindow' + 2)
+		mat `diff' = `post_total' - `pre_total'
 		di as text _n "DiD estimate:"
-		di diff_scalar
+		di `diff'[1,1] 
+		
+		di as text _n "DiD Estimate and SE from nlcom"
+		#d;
+		nlcom  ((_b[ _k_eq_p0] + _b[ _k_eq_p1] + _b[ _k_eq_p2] + _b[ _k_eq_p3] 
+			+ _b[ _k_eq_p4] + _b[ _k_eq_p5] + _b[ _k_eq_p6]) / (`rwindow' + 2)) 
+			- ((_b[_k_eq_m6] + _b[_k_eq_m5] + _b[_k_eq_m4] + _b[_k_eq_m3] + 
+			_b[_k_eq_m2]) / (`lwindow' + 1)), cformat(%9.4g)
+		;
+		#d cr
 	}
-	
 	* Trend adjustment by GMM
 	
 	if "`methodt'"=="gmm" {

--- a/xtevent/_eventols.ado
+++ b/xtevent/_eventols.ado
@@ -195,27 +195,19 @@ program define _eventols, rclass
 	gen byte `esample' = e(sample)
 	
 	* DiD estimate 
-	tempname pre_mat post_mat pre_total post_total diff diff_scalar
-	loc lwindow abs(`lwindow')
+	
+	loc lwindow = abs(`lwindow')
 	loc rwindow `rwindow'
 	if "`staticDD'"!=""{
-		mat `pre_mat' = `delta'[1...,1..`lwindow'] 
-		mat `post_mat' = `delta'[1...,(1+`lwindow')...]
-		mat `pre_total' = (`pre_mat' * J(colsof(`pre_mat'), 1, 1)) / (`lwindow' + 1)
-		mat `post_total' = (`post_mat' * J(colsof(`post_mat'), 1, 1)) / (`rwindow' + 2)
-		mat `diff' = `post_total' - `pre_total'
-		di as text _n "DiD estimate:"
-		di `diff'[1,1] 
-		
-		di as text _n "DiD estimate and standard error from nlcom:"
+		di as text _n "DiD estimate and standard error from lincom:"
 		#d;
-		nlcom  ((_b[ _k_eq_p0] + _b[ _k_eq_p1] + _b[ _k_eq_p2] + _b[ _k_eq_p3] 
+		lincom  ((_b[ _k_eq_p0] + _b[ _k_eq_p1] + _b[ _k_eq_p2] + _b[ _k_eq_p3] 
 			+ _b[ _k_eq_p4] + _b[ _k_eq_p5] + _b[ _k_eq_p6]) / (`rwindow' + 2)) 
 			- ((_b[_k_eq_m6] + _b[_k_eq_m5] + _b[_k_eq_m4] + _b[_k_eq_m3] + 
-			_b[_k_eq_m2]) / (`lwindow' + 1)), cformat(%9.4g) nohead
-		;
+			_b[_k_eq_m2]) / (`lwindow' + 1)), cformat(%9.4g);
 		#d cr
 	}
+	
 	* Trend adjustment by GMM
 	
 	if "`methodt'"=="gmm" {

--- a/xtevent/_eventols.ado
+++ b/xtevent/_eventols.ado
@@ -207,12 +207,12 @@ program define _eventols, rclass
 		di as text _n "DiD estimate:"
 		di `diff'[1,1] 
 		
-		di as text _n "DiD Estimate and SE from nlcom"
+		di as text _n "DiD estimate and standard error from nlcom:"
 		#d;
 		nlcom  ((_b[ _k_eq_p0] + _b[ _k_eq_p1] + _b[ _k_eq_p2] + _b[ _k_eq_p3] 
 			+ _b[ _k_eq_p4] + _b[ _k_eq_p5] + _b[ _k_eq_p6]) / (`rwindow' + 2)) 
 			- ((_b[_k_eq_m6] + _b[_k_eq_m5] + _b[_k_eq_m4] + _b[_k_eq_m3] + 
-			_b[_k_eq_m2]) / (`lwindow' + 1)), cformat(%9.4g)
+			_b[_k_eq_m2]) / (`lwindow' + 1)), cformat(%9.4g) nohead
 		;
 		#d cr
 	}

--- a/xtevent/_eventols.ado
+++ b/xtevent/_eventols.ado
@@ -196,16 +196,21 @@ program define _eventols, rclass
 	
 	* DiD estimate 
 	
-	loc lwindow = abs(`lwindow')
-	loc rwindow `rwindow'
 	if "`diffavg'"!=""{
-		di as text _n "DiD estimate and standard error from lincom:"
-		#d;
-		lincom  ((_b[ _k_eq_p0] + _b[ _k_eq_p1] + _b[ _k_eq_p2] + _b[ _k_eq_p3] 
-			+ _b[ _k_eq_p4] + _b[ _k_eq_p5] + _b[ _k_eq_p6]) / (`rwindow' + 2)) 
-			- ((_b[_k_eq_m6] + _b[_k_eq_m5] + _b[_k_eq_m4] + _b[_k_eq_m3] + 
-			_b[_k_eq_m2]) / (`lwindow' + 1)), cformat(%9.4g);
-		#d cr
+		unab pre : _k_eq_m*
+		unab post_p : _k_eq_p*
+		loc norma = abs(`norm')
+		loc pre : subinstr local pre "_k_eq_m`norma'" "", all
+		loc pre_plus : subinstr local pre " " " + ", all
+		loc reverse = ustrreverse("`pre_plus'")
+		loc reverse = subinstr("`reverse'", " + ", "", 1)
+		loc pre_plus = ustrreverse("`reverse'")
+		loc post_plus : subinstr local post_p " " " + ", all
+		loc lwindow = abs(`lwindow')
+		loc rwindow = `rwindow'
+		
+		di as text _n "Difference in pre and post-period averages from lincom:"
+		lincom ((`post_plus') / (`rwindow' + 2)) - ((`pre_plus') / (`lwindow' + 1)), cformat(%9.4g)
 	}
 	
 	* Trend adjustment by GMM

--- a/xtevent/_eventols.ado
+++ b/xtevent/_eventols.ado
@@ -21,7 +21,7 @@ program define _eventols, rclass
 	reghdfe /* Use reghdfe for estimation */	
 	impute(string) /*imputation on policyvar*/
 	absorb(string) /* Absorb additional variables in reghdfe */ 
-	staticDD /* Obtain regular DiD estimate implied by the model */
+	DIFFavg /* Obtain regular DiD estimate implied by the model */
 	*
 	]
 	;
@@ -198,7 +198,7 @@ program define _eventols, rclass
 	
 	loc lwindow = abs(`lwindow')
 	loc rwindow `rwindow'
-	if "`staticDD'"!=""{
+	if "`diffavg'"!=""{
 		di as text _n "DiD estimate and standard error from lincom:"
 		#d;
 		lincom  ((_b[ _k_eq_p0] + _b[ _k_eq_p1] + _b[ _k_eq_p2] + _b[ _k_eq_p3] 

--- a/xtevent/xtevent.sthlp
+++ b/xtevent/xtevent.sthlp
@@ -170,10 +170,10 @@ the unadopted-policy-state value, and the last-observed value must be the adopte
 or by the adopted-policy state. 
 
 {phang}
-{opt static} estimates a static panel data model and does not generate or plot event-time dummies. {opt static} is not allowed with {opt window}.
+{opt static} estimates a static panel data model and does not generate or plot event-time dummies. {opt static} is not allowed with {opt window} or {opt staticDD}.
 
 {phang}
-{opt staticDD} estimates a static difference-in-differences model via lincom and does not generate or plot event-time dummies. {opt staticDD} is allowed with {opt window}.
+{opt staticDD} estimates a static difference-in-differences model via lincom and does not generate or plot event-time dummies. {opt staticDD} is allowed with {opt window}. {opt staticDD} is not allowed with {opt static}.
 
 {phang}
 {opt tr:end(#1, [subopt])} extrapolates a linear trend between time periods from period #1 before the policy change, as in Dobkin et al. (2018). The estimated

--- a/xtevent/xtevent.sthlp
+++ b/xtevent/xtevent.sthlp
@@ -44,6 +44,7 @@
 {synopt:{opt note}} omit time fixed effects {p_end}
 {synopt: {opt impute(type, [saveimp])}} impute missing values in policyvar{p_end}
 {synopt:{opt st:atic}} estimate static model {p_end}
+{synopt:{opt staticDD}} estimate the regular DiD coefficient and standard error implied by the model {p_end}
 {synopt:{opt tr:end(#1, [subopt])}} extrapolate linear trend from time period #1 before treatment{p_end}
 {synopt:{opt savek(stub)}} save time-to-event, event-time and trend variables{p_end}
 {synopt: {opt kvars(stub)}} use previously generated even-time variables{p_end}
@@ -170,6 +171,9 @@ or by the adopted-policy state.
 
 {phang}
 {opt static} estimates a static panel data model and does not generate or plot event-time dummies. {opt static} is not allowed with {opt window}.
+
+{phang}
+{opt staticDD} estimates a static difference-in-differences model via lincom and does not generate or plot event-time dummies. {opt staticDD} is allowed with {opt window}.
 
 {phang}
 {opt tr:end(#1, [subopt])} extrapolates a linear trend between time periods from period #1 before the policy change, as in Dobkin et al. (2018). The estimated

--- a/xtevent/xtevent.sthlp
+++ b/xtevent/xtevent.sthlp
@@ -44,7 +44,7 @@
 {synopt:{opt note}} omit time fixed effects {p_end}
 {synopt: {opt impute(type, [saveimp])}} impute missing values in policyvar{p_end}
 {synopt:{opt st:atic}} estimate static model {p_end}
-{synopt:{opt staticDD}} estimate the regular DiD coefficient and standard error implied by the model {p_end}
+{synopt:{opt diffavg}} estimate the regular DiD coefficient and standard error implied by the model {p_end}
 {synopt:{opt tr:end(#1, [subopt])}} extrapolate linear trend from time period #1 before treatment{p_end}
 {synopt:{opt savek(stub)}} save time-to-event, event-time and trend variables{p_end}
 {synopt: {opt kvars(stub)}} use previously generated even-time variables{p_end}
@@ -170,10 +170,10 @@ the unadopted-policy-state value, and the last-observed value must be the adopte
 or by the adopted-policy state. 
 
 {phang}
-{opt static} estimates a static panel data model and does not generate or plot event-time dummies. {opt static} is not allowed with {opt window} or {opt staticDD}.
+{opt static} estimates a static panel data model and does not generate or plot event-time dummies. {opt static} is not allowed with {opt window} or {opt diffavg}.
 
 {phang}
-{opt staticDD} estimates a static difference-in-differences model via lincom and does not generate or plot event-time dummies. {opt staticDD} is allowed with {opt window}. {opt staticDD} is not allowed with {opt static}.
+{opt diffavg} estimates a static difference-in-differences model via lincom and does not generate or plot event-time dummies. {opt diffavg} is allowed with {opt window}. {opt diffavg} is not allowed with {opt static}.
 
 {phang}
 {opt tr:end(#1, [subopt])} extrapolates a linear trend between time periods from period #1 before the policy change, as in Dobkin et al. (2018). The estimated

--- a/xtevent/xtevent.sthlp
+++ b/xtevent/xtevent.sthlp
@@ -141,7 +141,8 @@ be used as an instrument.
 {cmd:proxyiv(select)} is the default for the one proxy, one instrument case, and it is only available in this case. 
 
 {phang2}
-{cmd:proxyiv(# ...)} specifies a numlist with the leads of the differenced policy variable as instruments. For example, {cmd:proxyiv(1 2)} specifies that the two first leads of the difference of the policy variable will be used as instruments.
+{cmd:proxyiv(# ...)} specifies a numlist with the leads of the differenced policy variable as instruments. For example, 
+{cmd:proxyiv(1 2)} specifies that the two first leads of the difference of the policy variable will be used as instruments.
 
 {phang2}
 {cmd:proxyiv(varlist)} specifies a {it:varlist} with the additional variables to be used as instruments.
@@ -153,11 +154,13 @@ be used as an instrument.
 {opt note} excludes time fixed effects.
 
 {phang}
-{opt impute(type, [saveimp])} imputes missing values in {it:policyvar} and uses this new variable as the actual {it:policyvar}. {cmd:type} determines the imputation rule. The suboption {cmd:saveimp} adds the new variable to the database as 
+{opt impute(type, [saveimp])} imputes missing values in {it:policyvar} and uses this new variable as the actual {it:policyvar}. 
+{cmd:type} determines the imputation rule. The suboption {cmd:saveimp} adds the new variable to the database as 
 {it:policyvar_imputed}. The following imputation types ca be implemented:
 
 {phang2}
-{cmd:impute(nuchange)} imputes missing values in {it:policyvar} according to {it:no-unobserved change}: it assumes that, for each unit: i) in periods before the first observed value, the policy value is the same as the first observed value; and
+{cmd:impute(nuchange)} imputes missing values in {it:policyvar} according to {it:no-unobserved change}: it assumes that, 
+for each unit: i) in periods before the first observed value, the policy value is the same as the first observed value; and
  ii) in periods after the last observed value, the policy value is the same as the last observed value.
 
 {phang2}
@@ -173,7 +176,8 @@ or by the adopted-policy state.
 {opt static} estimates a static panel data model and does not generate or plot event-time dummies. {opt static} is not allowed with {opt window} or {opt diffavg}.
 
 {phang}
-{opt diffavg} estimates a simple difference in averages between the post and pre-treatment periods via lincom. {opt diffavg} is allowed with {opt window}. {opt diffavg} is not allowed with {opt static}.
+{opt diffavg} calculates the difference in averages between the post-event estimated coefficients and the pre-event estimated coefficients periods. It also
+calculates its standard error with {help lincom}. {opt diffavg} is not allowed with {opt static}.
 
 {phang}
 {opt tr:end(#1, [subopt])} extrapolates a linear trend between time periods from period #1 before the policy change, as in Dobkin et al. (2018). The estimated

--- a/xtevent/xtevent.sthlp
+++ b/xtevent/xtevent.sthlp
@@ -44,7 +44,7 @@
 {synopt:{opt note}} omit time fixed effects {p_end}
 {synopt: {opt impute(type, [saveimp])}} impute missing values in policyvar{p_end}
 {synopt:{opt st:atic}} estimate static model {p_end}
-{synopt:{opt diffavg}} estimate the simple difference in averages between the post and pre-periods {p_end}
+{synopt:{opt diffavg}} estimate the difference in averages between the post and pre-periods {p_end}
 {synopt:{opt tr:end(#1, [subopt])}} extrapolate linear trend from time period #1 before treatment{p_end}
 {synopt:{opt savek(stub)}} save time-to-event, event-time and trend variables{p_end}
 {synopt: {opt kvars(stub)}} use previously generated even-time variables{p_end}

--- a/xtevent/xtevent.sthlp
+++ b/xtevent/xtevent.sthlp
@@ -44,7 +44,7 @@
 {synopt:{opt note}} omit time fixed effects {p_end}
 {synopt: {opt impute(type, [saveimp])}} impute missing values in policyvar{p_end}
 {synopt:{opt st:atic}} estimate static model {p_end}
-{synopt:{opt diffavg}} estimate the regular DiD coefficient and standard error implied by the model {p_end}
+{synopt:{opt diffavg}} estimate the simple difference in averages between the post and pre-periods {p_end}
 {synopt:{opt tr:end(#1, [subopt])}} extrapolate linear trend from time period #1 before treatment{p_end}
 {synopt:{opt savek(stub)}} save time-to-event, event-time and trend variables{p_end}
 {synopt: {opt kvars(stub)}} use previously generated even-time variables{p_end}
@@ -173,7 +173,7 @@ or by the adopted-policy state.
 {opt static} estimates a static panel data model and does not generate or plot event-time dummies. {opt static} is not allowed with {opt window} or {opt diffavg}.
 
 {phang}
-{opt diffavg} estimates a static difference-in-differences model via lincom and does not generate or plot event-time dummies. {opt diffavg} is allowed with {opt window}. {opt diffavg} is not allowed with {opt static}.
+{opt diffavg} estimates a simple difference in averages between the post and pre-treatment periods via lincom. {opt diffavg} is allowed with {opt window}. {opt diffavg} is not allowed with {opt static}.
 
 {phang}
 {opt tr:end(#1, [subopt])} extrapolates a linear trend between time periods from period #1 before the policy change, as in Dobkin et al. (2018). The estimated


### PR DESCRIPTION
Closes #16.

Implemented the changes we discussed today. Calling the staticDD option now displays the lincom estimate table with 4 significant figures. Matrixes are no longer in play.